### PR TITLE
Add support for the preprocess_html flag.

### DIFF
--- a/lib/html/pipeline/rouge_filter.rb
+++ b/lib/html/pipeline/rouge_filter.rb
@@ -13,8 +13,7 @@ module HTML
           default   = must_str(context[:highlight])
           next unless lang = node["lang"] || default
           next unless lexer = lexer_for(lang)
-          node.css("br").each { |br| br.replace("\n") } if replace_br
-          text = node.inner_text
+          text = preprocess_html(node)
           html = highlight_with(lexer, text)
           next if html.nil?
 
@@ -26,6 +25,15 @@ module HTML
         end
 
         doc
+      end
+
+      def preprocess_html(node)
+        node.css("br").each { |br| br.replace("\n") } if replace_br?
+        result = node.inner_text
+        return result unless preprocess_html?
+
+        result.tr!("\u00A0", ' ')
+        result
       end
 
       def highlight_with(lexer, text)
@@ -40,8 +48,12 @@ module HTML
         context[:line_numbers] || false
       end
 
-      def replace_br
-        context[:replace_br] || false
+      def replace_br?
+        context[:replace_br] || preprocess_html?
+      end
+
+      def preprocess_html?
+        context[:preprocess_html] || false
       end
 
       def formatter(css_class: default_css_class)

--- a/test/rouge_filter_test.rb
+++ b/test/rouge_filter_test.rb
@@ -95,6 +95,16 @@ class HTML::Pipeline::RougeFilterTest < Minitest::Test
 
     doc = filter.call
     assert_equal "<pre class=\"highlight highlight-ruby\"><code>"\
+                 "<span class=\"n\">hello</span>\n"\
+                 "<span class=\"n\">world</span></code></pre>\n", doc.to_html
+  end
+
+  def test_preprocess_html
+    filter = RougeFilter.new \
+      "<pre lang='ruby'> &nbsp;hello<br>world</pre>", preprocess_html: true
+
+    doc = filter.call
+    assert_equal "<pre class=\"highlight highlight-ruby\"><code>  "\
                  "<span class=\"n\">hello</span>\n<span class=\"n\">world</span></code></pre>\n", doc.to_html
   end
 end


### PR DESCRIPTION
This adds support for replacing consecutive spaces/nbsp to be converted to plain spaces for use with the Rouge lexer.

Fixes #8.
